### PR TITLE
Wade/bug fixes

### DIFF
--- a/spdx_review.py
+++ b/spdx_review.py
@@ -52,7 +52,7 @@ def report_differences(old_dict, new_dict):
         if new['copyrights'] != old['copyrights']:
             print(f"WARN: {fname} Copyright has changed from " \
                   f"{old['copyrights']} to {new['copyrights']}")
-        elif new['license_expressions'] != old['license_expressions']:
+        if new['license_expressions'] != old['license_expressions']:
             print(f"WARN: {fname} License Expression has changed from " \
                   f"{old['license_expressions']} to {new['license_expressions']}")
 


### PR DESCRIPTION
A couple of minor bug fixes:

1. The locally installed version of scancode (following the README.md) changed the copyright dict key name from 'copyright' to 'value'.
2. The report_differences function 'elif' statement changed to 'if' so could report both copyright and license expression changes to a single file.