### PR TITLE
spdx_review: ignore directories

### DIFF
--- a/spdx_review.py
+++ b/spdx_review.py
@@ -30,7 +30,7 @@ def create_cl_dict(json_file):
         data = json.load(f)
     final_dict = {}
     for dic in data['files']:
-        if "type" in dic or dic['type'] == "file":
+        if "type" in dic and dic['type'] == "file":
             tmp_dict = {}
             tmp_dict['file_type']           = dic['file_type']
             tmp_dict['license_expressions'] = dic['license_expressions']


### PR DESCRIPTION
Directories don't have licenses or copyrights, so ignore them. In fact we can ignore anything that is not a file.