### PR TITLE
entrypoint: disable safe.directory checks

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,8 @@ PRNUM=${PR%"/merge"}
 # Github REST API endpoints
 BODY_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PRNUM}/comments"
 
+git config --global --add safe.directory $(pwd)
+
 git fetch --no-tags --progress --no-recurse-submodules \
 	--depth=1 origin "$GITHUB_BASE_REF"
 


### PR DESCRIPTION
A recent git change now checks for the permissions of directories, which can cause an error like during workflows:

    fatal: detected dubious ownership in repository at /github/workspace
    To add an exception for this directory, call:

    git config --global --add safe.directory /github/workspace

So add the suggested git config to entrypoint.sh.

Note that --global is required because when github checks out the code on the workflow, the directory is owned by "1001:123" so we can't write in to the .git/ directory.