### PR TITLE
Fix Recent Breakage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get install -y bzip2 xz-utils zlib1g libxml2-dev libxslt1-dev python3-pi
 
 RUN pip install --upgrade pip setuptools wheel
 
-RUN pip install scancode-toolkit
+RUN pip install scancode-toolkit==32.0.7
 
 COPY spdx_review.py /spdx_review.py
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,11 @@ LOG="spdx_review.log"
 REVIEW_ARGS=(-l "$LOG" -g "origin/$GITHUB_BASE_REF" "origin/$GITHUB_HEAD_REF")
 
 echo "Run spdx_review.py" "${REVIEW_ARGS[@]}"
-python3 /spdx_review.py "${REVIEW_ARGS[@]}" || true
+python3 /spdx_review.py "${REVIEW_ARGS[@]}" || EXIT_CODE=$?
+if [ "$EXIT_CODE" != "" -a "$EXIT_CODE" != 1 ]; then
+	echo "FAILURE ($EXIT_CODE)"
+	exit 1
+fi
 
 if [[ -s "$LOG" ]]; then
     SPDX_RESULT=$(cat "$LOG")

--- a/spdx_review.py
+++ b/spdx_review.py
@@ -34,7 +34,8 @@ def create_cl_dict(json_file):
         if "type" in dic and dic['type'] == "file":
             tmp_dict = {}
             tmp_dict['file_type']           = dic['file_type']
-            tmp_dict['license_expressions'] = dic['license_expressions']
+            tmp_dict['detected_license_expression'] = \
+                    dic['detected_license_expression']
             tmp_dict['copyrights']          = mk_copyright_list(dic)
             fpath = strip_directory(dic['path'])
             final_dict[fpath] = tmp_dict
@@ -49,10 +50,10 @@ def report_differences(old_dict, new_dict):
             eid_cpy = any("eidetic" in cpyr.lower()
                           for cpyr in new['copyrights'])
 
-            if not eid_cpy and not new['license_expressions']:
-                logging.warning(f"New file {fname} is showing no license_expressions: {new['license_expressions']}")
+            if not eid_cpy and not new['detected_license_expression']:
+                logging.warning(f"New file {fname} is showing no license: {new['detected_license_expression']}")
             else:
-                logging.info(f"INFO: New file {fname} is showing license_expressions: {new['license_expressions']}")
+                logging.info(f"INFO: New file {fname} is showing license_expressions: {new['detected_license_expression']}")
             if not new['copyrights']:
                 error_flag = True
                 logging.error(f"New file {fname} is showing no copyrights: {new['copyrights']}")
@@ -66,8 +67,8 @@ def report_differences(old_dict, new_dict):
                 logging.error(f"{fname} is showing no copyrights: {new['copyrights']}")
             else:
                 logging.warning(f"{fname} Copyright has changed from {old['copyrights']} to {new['copyrights']}")
-        if new['license_expressions'] != old['license_expressions']:
-            logging.warning(f"{fname} License Expression has changed from {old['license_expressions']} to {new['license_expressions']}")
+        if new['detected_license_expression'] != old['detected_license_expression']:
+            logging.warning(f"{fname} License Expression has changed from {old['detected_license_expression']} to {new['detected_license_expression']}")
     return error_flag
 
 def run_scancode(directory):

--- a/spdx_review.py
+++ b/spdx_review.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import tempfile
 import logging
 import sys
+import traceback
 
 def mk_copyright_list(dic):
     copyright_list = []
@@ -128,3 +129,6 @@ if __name__ == "__main__":
     except (subprocess.SubprocessError,
             FileNotFoundError) as e:
         print(e)
+    except Exception as e:
+        traceback.print_exc()
+        sys.exit(3)


### PR DESCRIPTION
The workflow has recently started failing silently with the following error:

```console
$ spdx_review.py -l spdx_review.log -g origin/next origin/blacklist_err
Traceback (most recent call last):
  File "/spdx_review.py", line 123, in <module>
    old_dict = scancode_git_dir(args.before, args.git_dir)
  File "/spdx_review.py", line 83, in scancode_git_dir
    return run_scancode(tmp_scandir)
  File "/spdx_review.py", line 76, in run_scancode
    return create_cl_dict(tmp_base.name)
  File "/spdx_review.py", line 36, in create_cl_dict
    tmp_dict['license_expressions'] = dic['license_expressions']
KeyError: 'license_expressions'
```

This was caused by changes to the most recent version of scan code.

This PR fixes the fact that errors are silently ignored, fixes the breakage by adjusting the license_expressions 
value to detected_license_expression, and pins scancode to the latest version to avoid further random breaks.